### PR TITLE
Making Footer Configurable

### DIFF
--- a/site/config.toml
+++ b/site/config.toml
@@ -20,6 +20,7 @@ theme = "nightfall"
 author = "rust-bitcoin"
 user = "dev"
 hostname = "rust-bitcoin.org"
+footerHTML = 'License CC-01 , Built with <a href="https://gohugo.io" class="footerLink">Hugo</a> and <a href="https://github.com/LordMathis/hugo-theme-nightfall" class="footerLink">Nightfall</a> theme'
 
 [[params.social]]
 key = 0


### PR DESCRIPTION
Closes #1 

This was less complicated to replicate. I have just added the configuration option in the config.toml and the theme can just pick the footer directly from there based on whatever we decide to do.

Edit : The Nightfall theme author has helped us for dealing with a configurable footerHTML and I have just used it as it is.