### PR TITLE
fix(README): markdown URLs should be enclose in `

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Website source for www.rust-bitcoin.org
+# Website source for `www.rust-bitcoin.org`
 
 While the website is deployed at rust-bitcoin.org there are still missing parts such as the cookbook.
 We will be happy to receive contributions adding interesting examples.


### PR DESCRIPTION
Just a quick fix so I can run CI in #9.
https://github.com/rust-bitcoin/www.rust-bitcoin.org/pull/9#issuecomment-1734577512

Cc @tcharding 