### PR TITLE
ci: Hugo extended version in `peaceiris/actions-hugo`

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -31,6 +31,7 @@ jobs:
         uses: peaceiris/actions-hugo@v2
         with:
           hugo-version: "latest"
+          extended: true
 
       - name: Build Hugo
         working-directory: ./site


### PR DESCRIPTION
Fixes the [Hugo error in CI](https://github.com/rust-bitcoin/www.rust-bitcoin.org/actions/runs/6436168630/job/17478960161#step:6:10). The error message is:

```shell
Error: error building site: TOCSS: failed to transform "sass/main.scss" (text/x-scss). Check your Hugo installation; you need the extended version to build SCSS/SASS with transpiler set to 'libsass'.: this feature is not available in your current Hugo version, see https://goo.gl/YMrWcn for more information
```

If you go to the [Hugo FAQ](https://gohugo.io/troubleshooting/faq/#i-get--this-feature-is-not-available-in-your-current-hugo-version), you'll see the following explanation:

> We release two set of binaries for technical reasons.
> The extended version is not what you get by default
> for some installation methods.
> On the release page, look for archives with extended in the name.

We fix this by using the [`extended`](https://github.com/peaceiris/actions-hugo?tab=readme-ov-file#%EF%B8%8F-use-hugo-extended) option in `peaceiris/actions-hugo`:

```yaml
extended: true
```

Now the page should build with hugo.